### PR TITLE
chore: migrate to new TypeScriptService.getQuickInfoAt API

### DIFF
--- a/src/main/kotlin/yij/ie/ideacommentqueries/providers/TS.kt
+++ b/src/main/kotlin/yij/ie/ideacommentqueries/providers/TS.kt
@@ -95,11 +95,7 @@ class TS: InlayHintsProvider<Settings> {
                 val ele = nFile.findElementAt(offset) ?: return null
 
                 val tss = TypeScriptService.getForFile(nFile.project, nFile.virtualFile) ?: return null
-                val quickInfo = tss.getQuickInfoAt(
-                    ele,
-                    ele.originalElement,
-                    nFile.originalFile.virtualFile
-                )
+                val quickInfo = tss.getQuickInfoAt(ele, nFile.virtualFile)
                 val retryTimes = 3
                 for (i in 1..retryTimes) {
                     try {


### PR DESCRIPTION
Hello! I'm bringing a small change around TypeScriptService API.

BTW, I've noticed that [2.1.1](https://github.com/NWYLZW/idea-comment-queries/releases/tag/2.1.1) version hasn't been uploaded to JetBrains Marketplace – meaning that the users of 2023.3 can't update the plugin. Was it intentional?